### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.json]
+indent_style = space
+indent_size = 2
+
+[*.tsx]
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_style = space
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 
 - **Python**: Follow PEP 8, use type hints, 90%+ test coverage
 - **TypeScript**: Strict mode, ESLint + Prettier, comprehensive testing
+- **EditorConfig**: Consistent indentation and line endings via [.editorconfig](.editorconfig)
 - **Git**: Conventional commits, meaningful commit messages
 - **Documentation**: Update docs for any API changes
 


### PR DESCRIPTION
## Summary
- create `.editorconfig` specifying indentation and encoding rules
- mention `.editorconfig` in README under Code Standards

## Testing
- `npm test` *(fails: unrecognized arguments for pytest)*

------
https://chatgpt.com/codex/tasks/task_e_684ca69534a083328696ba21abf3ffcf